### PR TITLE
♻️ refactor[api/posts]: Update R2 bucket environment variables

### DIFF
--- a/app/api/posts/create/route.ts
+++ b/app/api/posts/create/route.ts
@@ -6,10 +6,10 @@ import { v4 as uuidv4 } from "uuid";
 import { S3Client, PutObjectCommand } from "@aws-sdk/client-s3";
 
 // Cloudflare R2 settings
-const R2_BUCKET_NAME = process.env.R2_BUCKET_NAME;
-const R2_ACCESS_KEY = process.env.R2_ACCESS_KEY;
-const R2_SECRET_KEY = process.env.R2_SECRET_KEY;
-const R2_ACCOUNT_ID = process.env.R2_ACCOUNT_ID;
+const R2_BUCKET_NAME = process.env.DESTINATION_BUCKET_NAME;
+const R2_ACCESS_KEY = process.env.DESTINATION_ACCESS_KEY;
+const R2_SECRET_KEY = process.env.DESTINATION_SECRET_KEY;
+const R2_ACCOUNT_ID = process.env.DESTINATION_ACCOUNT_ID;
 const R2_ENDPOINT = `https://${R2_ACCOUNT_ID}.r2.cloudflarestorage.com`;
 
 const s3Client = new S3Client({
@@ -57,7 +57,7 @@ async function uploadImagesFromContent(content: string): Promise<string> {
       );
 
       // Create new URL from Cloudflare R2
-      const newImageUrl = `https://bso-image.posyayee.shop/${newFileName}`;
+      const newImageUrl = `https://assets.bsospace.com/${newFileName}`;
       content = content.replace(imgSrc, newImageUrl); // Replace original URL with new URL
 
       uploads.push(uploadPromise);

--- a/app/api/posts/edit/[id]/route.ts
+++ b/app/api/posts/edit/[id]/route.ts
@@ -32,6 +32,17 @@ async function uploadImagesFromContent(content: string): Promise<string> {
 
     // If it's not an external URL (e.g., https://), consider it a blob
     const isExternalUrl = imgSrc.startsWith("https://");
+    const oldBucketUrl = imgSrc.startsWith("https://bso-image.posyayee.shop/");
+
+    if (oldBucketUrl) {
+      const newImageUrl = imgSrc.replace(
+        "https://bso-image.posyayee.shop/",
+        `https://assets.bsospace.com/`
+      );
+
+      content = content.replace(imgSrc, newImageUrl);
+    }
+
     if (!isExternalUrl) {
       // Separate the image type and base64 data
       const base64Data = imgSrc.split(";base64,").pop();


### PR DESCRIPTION

This pull request includes updates to the environment variable names and URL formats for image uploads in the `posts` API routes. The changes ensure consistency in the naming conventions and the URLs used for accessing images.

Environment variable updates:

* [`app/api/posts/create/route.ts`](diffhunk://#diff-0ead395f17ac01229bfbabd02130b0187c263e22dc27b336b2aeca98897dc8daL9-R12): Updated environment variable names from `R2_*` to `DESTINATION_*` for better clarity and consistency.

URL format updates:

* [`app/api/posts/create/route.ts`](diffhunk://#diff-0ead395f17ac01229bfbabd02130b0187c263e22dc27b336b2aeca98897dc8daL60-R60): Changed the base URL for new images from `https://bso-image.posyayee.shop/` to `https://assets.bsospace.com/`.
* `app/api/posts/edit/[id]/route.ts`: Added logic to update old image URLs from `https://bso-image.posyayee.shop/` to `https://assets.bsospace.com/` in the content. ([app/api/posts/edit/[id]/route.tsR35-R45](diffhunk://#diff-40015657b24f839c05fde4629490fd63eb637bae8664f4e6a327a4c1d54bf4d5R35-R45))