### PR TITLE
✨ feat[layout]: display latest version in footer by fetching from GitHub

### DIFF
--- a/app/components/Layout.tsx
+++ b/app/components/Layout.tsx
@@ -1,19 +1,44 @@
 "use client";
-import { ReactNode } from "react";
+import { ReactNode, useEffect, useState } from "react";
 import ThemeSwitcher from "./ThemeSwitcher";
 import Image from "next/image";
 import logo from "../../public/BSO LOGO.svg";
 import Link from "next/link";
+import axios from "axios";
 
-interface LayoutProps {
-  children: ReactNode;
-}
+export default function Layout({ children }: { children: ReactNode }) {
+  const [version, setVersion] = useState<string>("unknown");
 
-export default function Layout({ children }: LayoutProps) {
+  useEffect(() => {
+    const fetchLatestVersion = async () => {
+      try {
+        const response = await axios.get(
+          "https://api.github.com/repos/bsospace/BSOSpace-Blog-Frontend/releases/latest"
+        );
+        setVersion(response.data.tag_name || "unknown");
+      } catch (error) {
+        console.error("Error fetching latest version from GitHub:", error);
+        setVersion("unknown");
+      }
+    };
+
+    fetchLatestVersion();
+  }, []);
+
   return (
     <div className="flex flex-col min-h-screen dark:bg-space-dark bg-space-light">
-        {/* eslint-disable-next-line @next/next/no-sync-scripts */}
-        <script data-name="BMC-Widget" data-cfasync="false" src="https://cdnjs.buymeacoffee.com/1.0.0/widget.prod.min.js" data-id="bsospace" data-description="Support me on Buy me a coffee!" data-message="" data-color="#FF813F" data-position="Right" data-x_margin="18" data-y_margin="18"></script>
+      <script
+        data-name="BMC-Widget"
+        data-cfasync="false"
+        src="https://cdnjs.buymeacoffee.com/1.0.0/widget.prod.min.js"
+        data-id="bsospace"
+        data-description="Support me on Buy me a coffee!"
+        data-message=""
+        data-color="#FF813F"
+        data-position="Right"
+        data-x_margin="18"
+        data-y_margin="18"
+      ></script>
       {/* Header */}
       <header className="sticky top-0 p-2 z-50 bg-white dark:bg-[#1F1F1F] shadow-md">
         <div className="container mx-auto px-4 flex justify-between items-center">
@@ -55,8 +80,8 @@ export default function Layout({ children }: LayoutProps) {
       {/* Footer */}
       <footer className="bg-white dark:bg-[#1F1F1F] py-4">
         <div className="container mx-auto text-center md:text-body-15pt-medium text-[10px]">
-          Be Simple but Outstanding | &copy; 2025 BSO Space Blog. All rights
-          reserved.
+          Be Simple but Outstanding | Version: {version} | &copy; 2025 BSO Space
+          Blog. All rights reserved.
         </div>
       </footer>
     </div>


### PR DESCRIPTION
This pull request includes changes to the `Layout` component in `app/components/Layout.tsx` to add version information fetched from the GitHub API and display it in the footer. Additionally, some code formatting improvements were made.

Fetching and displaying version information:

* [`app/components/Layout.tsx`](diffhunk://#diff-9aab0cbc1dd4a0f760b394681e7bdda83399e648b5651249ec19db79bfb49748L2-R41): Imported `useEffect`, `useState`, and `axios` to fetch the latest release version from the GitHub API and store it in the `version` state. The version is then displayed in the footer. [[1]](diffhunk://#diff-9aab0cbc1dd4a0f760b394681e7bdda83399e648b5651249ec19db79bfb49748L2-R41) [[2]](diffhunk://#diff-9aab0cbc1dd4a0f760b394681e7bdda83399e648b5651249ec19db79bfb49748L58-R84)

Code formatting improvements:

* [`app/components/Layout.tsx`](diffhunk://#diff-9aab0cbc1dd4a0f760b394681e7bdda83399e648b5651249ec19db79bfb49748L2-R41): Reformatted the `Buy me a coffee` widget script tag for better readability.